### PR TITLE
Fix WidgetGetParentOfClass not working when immediate parent is UserW…

### DIFF
--- a/Source/VictoryBPLibrary/Private/VictoryBPFunctionLibrary.cpp
+++ b/Source/VictoryBPLibrary/Private/VictoryBPFunctionLibrary.cpp
@@ -5110,6 +5110,15 @@ UUserWidget* UVictoryBPFunctionLibrary::WidgetGetParentOfClass(UWidget* ChildWid
 		UWidget* NextPossibleParent = nullptr;
 		int32 count = 0;
 
+		if (PossibleParent == nullptr)
+		{
+			UWidgetTree* WidgetTree = Cast<UWidgetTree>(ChildWidget->GetOuter());
+			if (WidgetTree)
+			{
+				PossibleParent = Cast<UWidget>(WidgetTree->GetOuter());
+			}
+		}
+
 		while (PossibleParent != nullptr)
 		{
 			// Return once we find a parent of the desired class.


### PR DESCRIPTION
Steps to reproduce:
Create a `UserWidget` called `MyWidget`
Create another `UserWidget` called `MyWidget2`
Remove the default `canvas panel` from `MyWidget2` and add `MyWidget` to it
Inside Graph of `MyWidget2`, use `WidgetGetParentOfClass(MyWidget2, UserWidget)`

Expected results: `WidgetGetParentOfClass` should return `MyWidget`
Actual results: `WidgetGetParentOfClass` returns null

Cause: On line 5109, `ChildWidget->GetParent()` returns null since the parent is a `UserWidget` hence the loop on line 5113 is never entered hence never using `GetOuter()` to reach `MyWidget`

Fix: If `ChildWidget->GetParent()` returns null, fall back to `GetOuter()`

Fixes issue as mentioned
https://github.com/EverNewJoy/VictoryPlugin/issues/9

Feel free to modify / tell me how you wish to fix this as my solution probably isn't the most elegant of ways