### PR TITLE
Added RemoveFromStreamingLevels function

### DIFF
--- a/Source/VictoryBPLibrary/Private/VictoryBPFunctionLibrary.cpp
+++ b/Source/VictoryBPLibrary/Private/VictoryBPFunctionLibrary.cpp
@@ -5328,7 +5328,7 @@ void UVictoryBPFunctionLibrary::RemoveFromStreamingLevels(UObject* WorldContextO
 			}
 			return packageName;
 		};
-#endif WITH_EDITOR
+#endif
 
 		// Get the package name that we want to check
 		FString packageNameToCheck = LevelInstanceInfo.PackageName.ToString();
@@ -5336,7 +5336,7 @@ void UVictoryBPFunctionLibrary::RemoveFromStreamingLevels(UObject* WorldContextO
 #if WITH_EDITOR
 		// Remove the play in editor string and client id to be able to use it with replication
 		packageNameToCheck = getCorrectPackageName(packageNameToCheck);
-#endif WITH_EDITOR
+#endif
 
 		// Find the level to unload
 		for (auto StreamingLevel : World->StreamingLevels)
@@ -5347,7 +5347,7 @@ void UVictoryBPFunctionLibrary::RemoveFromStreamingLevels(UObject* WorldContextO
 #if WITH_EDITOR
 			// Remove the play in editor string and client id to be able to use it with replication
 			loadedPackageName = getCorrectPackageName(loadedPackageName);
-#endif WITH_EDITOR
+#endif
 
 			// If we find the level unload it and break
 			if(packageNameToCheck == loadedPackageName)

--- a/Source/VictoryBPLibrary/Private/VictoryBPFunctionLibrary.cpp
+++ b/Source/VictoryBPLibrary/Private/VictoryBPFunctionLibrary.cpp
@@ -5314,7 +5314,7 @@ void UVictoryBPFunctionLibrary::RemoveFromStreamingLevels(UObject* WorldContextO
 
 #if WITH_EDITOR
 		// If we are using the editor we will use this lambda to remove the play in editor string
-		auto getCorrectPackageName = [&]( FName PackageName) {
+		auto GetCorrectPackageName = [&]( FName PackageName) {
 			FString PackageNameStr = PackageName.ToString();
 			if (GEngine->NetworkRemapPath(World->GetNetDriver(), PackageNameStr, true))
 			{
@@ -5330,7 +5330,7 @@ void UVictoryBPFunctionLibrary::RemoveFromStreamingLevels(UObject* WorldContextO
 
 #if WITH_EDITOR
 		// Remove the play in editor string and client id to be able to use it with replication
-		PackageNameToCheck = getCorrectPackageName(PackageNameToCheck);
+		PackageNameToCheck = GetCorrectPackageName(PackageNameToCheck);
 #endif
 
 		// Find the level to unload
@@ -5341,7 +5341,7 @@ void UVictoryBPFunctionLibrary::RemoveFromStreamingLevels(UObject* WorldContextO
 
 #if WITH_EDITOR
 			// Remove the play in editor string and client id to be able to use it with replication
-			LoadedPackageName = getCorrectPackageName(LoadedPackageName);
+			LoadedPackageName = GetCorrectPackageName(LoadedPackageName);
 #endif
 
 			// If we find the level unload it and break

--- a/Source/VictoryBPLibrary/Public/VictoryBPFunctionLibrary.h
+++ b/Source/VictoryBPLibrary/Public/VictoryBPFunctionLibrary.h
@@ -1860,6 +1860,9 @@ static bool Capture2D_Project(class ASceneCapture2D* Target, FVector Location, F
 	UFUNCTION(Category = "LevelStreaming", BlueprintCallable, Meta = (HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"))
 	static void AddToStreamingLevels(UObject* WorldContextObject, const FLevelStreamInstanceInfo& LevelInstanceInfo);
 	
+	UFUNCTION(Category = "LevelStreaming", BlueprintCallable, Meta = (HidePin = "WorldContextObject", DefaultToSelf = "WorldContextObject"))
+	static void RemoveFromStreamingLevels(UObject* WorldContextObject, const FLevelStreamInstanceInfo& LevelInstanceInfo);
+
 	static bool GenericArray_SortCompare(const UProperty* LeftProperty, void* LeftValuePtr, const UProperty* RightProperty, void* RightValuePtr);
 
 	/**


### PR DESCRIPTION
Added RemoveFromStreamingLevels function to allow the unloading of level instances across network replicating the level instance stream info.

I don't know how to handle well the behaviour in Editor as that adds UEDPIE_\<ClientID\>_ to the cached package name so for now I have removed that part of the string when we are playing in editor to be able to find the package name. It works, but I don't know if that is the best way to do it.