### PR TITLE
Added Box.Init() before building the selection box

### DIFF
--- a/Source/VictoryBPLibrary/Private/VictoryBPFunctionLibrary.cpp
+++ b/Source/VictoryBPLibrary/Private/VictoryBPFunctionLibrary.cpp
@@ -2221,6 +2221,7 @@ void UVictoryBPFunctionLibrary::Selection_SelectionBox(UObject* WorldContextObje
 	SelectedActors.Empty();
 	
 	FBox2D Box;
+	Box.Init();
 	Box+=DraggedPoint;
 	Box+=AnchorPoint;
 	


### PR DESCRIPTION
While using this code in C++ for selection, I ran into really weird problems, that in some sections of my code the box was not initialized properly and contained really small values by default (especially in debug builds) and behaved weird, due to not calling Box.Init().