### PR TITLE
Allow appending to file, on demand

### DIFF
--- a/Source/VictoryBPLibrary/Private/VictoryBPFunctionLibrary.cpp
+++ b/Source/VictoryBPLibrary/Private/VictoryBPFunctionLibrary.cpp
@@ -3011,6 +3011,7 @@ bool UVictoryBPFunctionLibrary::FileIO__SaveStringTextToFile(
 	FString JoyfulFileName, 
 	FString SaveText,
 	bool AllowOverWriting
+	bool AllowAppend
 ){
 	if(!FPlatformFileManager::Get().GetPlatformFile().CreateDirectoryTree(*SaveDirectory))
 	{
@@ -3034,9 +3035,15 @@ bool UVictoryBPFunctionLibrary::FileIO__SaveStringTextToFile(
 		}
 	}
 	
+	if (AllowAppend)
+	{
+		SaveText += "\n";
+		return FFileHelper::SaveStringToFile(SaveText, * SaveDirectory,
+				FFileHelper::EEncodingOptions::AutoDetect,&IFileManager::Get(), EFileWrite::FILEWRITE_Append);
+	}
 	return FFileHelper::SaveStringToFile(SaveText, * SaveDirectory);
 }
-bool UVictoryBPFunctionLibrary::FileIO__SaveStringArrayToFile(FString SaveDirectory, FString JoyfulFileName, TArray<FString> SaveText, bool AllowOverWriting)  
+bool UVictoryBPFunctionLibrary::FileIO__SaveStringArrayToFile(FString SaveDirectory, FString JoyfulFileName, TArray<FString> SaveText, bool AllowOverWriting, bool AllowAppend)  
 {
 	//Dir Exists?
 	if ( !VCreateDirectory(SaveDirectory))
@@ -3068,7 +3075,12 @@ bool UVictoryBPFunctionLibrary::FileIO__SaveStringArrayToFile(FString SaveDirect
 		FinalStr += LINE_TERMINATOR;
 	}
 	
-
+	if (AllowAppend)
+	{
+	    FinalStr += "\n";
+		return FFileHelper::SaveStringToFile(FinalStr, * SaveDirectory,
+				FFileHelper::EEncodingOptions::AutoDetect,&IFileManager::Get(), EFileWrite::FILEWRITE_Append);
+	}
 
 	return FFileHelper::SaveStringToFile(FinalStr, * SaveDirectory);
 	

--- a/Source/VictoryBPLibrary/Public/VictoryBPFunctionLibrary.h
+++ b/Source/VictoryBPLibrary/Public/VictoryBPFunctionLibrary.h
@@ -1194,11 +1194,11 @@ class VICTORYBPLIBRARY_API UVictoryBPFunctionLibrary : public UBlueprintFunction
 
 	/** Saves text to filename of your choosing, make sure include whichever file extension you want in the filename, ex: SelfNotes.txt . Make sure to include the entire file path in the save directory, ex: C:\MyGameDir\BPSavedTextFiles */
 	UFUNCTION(BlueprintCallable, Category = "Victory BP Library|File IO")
-	static bool FileIO__SaveStringTextToFile(FString SaveDirectory, FString JoyfulFileName, FString SaveText, bool AllowOverWriting = false);
+	static bool FileIO__SaveStringTextToFile(FString SaveDirectory, FString JoyfulFileName, FString SaveText, bool AllowOverWriting = false, bool AllowAppend = false);
 
 	/** Saves multiple Strings to filename of your choosing, with each string on its own line! Make sure include whichever file extension you want in the filename, ex: SelfNotes.txt . Make sure to include the entire file path in the save directory, ex: C:\MyGameDir\BPSavedTextFiles */
 	UFUNCTION(BlueprintCallable, Category = "Victory BP Library|File IO")
-	static bool FileIO__SaveStringArrayToFile(FString SaveDirectory, FString JoyfulFileName, TArray<FString> SaveText, bool AllowOverWriting = false);
+	static bool FileIO__SaveStringArrayToFile(FString SaveDirectory, FString JoyfulFileName, TArray<FString> SaveText, bool AllowOverWriting = false, bool AllowAppend = false);
 
 
 	/** Obtain an Array of Actors Rendered Recently. You can specifiy what qualifies as "Recent" in seconds. */


### PR DESCRIPTION
This functionality is slow compared to what can be obtained by not opening and closing file heads
Should only be used for debugging

Requires `AllowOverWriting` to be true