### PR TITLE
Compatibility changes for non-unity building

### DIFF
--- a/Source/VictoryBPLibrary/Public/VictoryPC.cpp
+++ b/Source/VictoryBPLibrary/Public/VictoryPC.cpp
@@ -6,7 +6,10 @@
 
 #include "VictoryBPLibraryPrivatePCH.h"
 #include "VictoryPC.h"
- 
+#include "HttpModule.h"
+#include "Components/AudioComponent.h"
+#include "Interfaces/IHttpResponse.h"
+
 #include "Runtime/Engine/Classes/Kismet/GameplayStatics.h"
 
 DEFINE_LOG_CATEGORY(VictoryPCLog)

--- a/Source/VictoryBPLibrary/Public/VictoryPC.h
+++ b/Source/VictoryBPLibrary/Public/VictoryPC.h
@@ -7,6 +7,8 @@
 
 //HTTP
 #include "Http.h"
+#include "Interfaces/IHttpRequest.h"
+
 
 #include "Runtime/Engine/Classes/GameFramework/PlayerController.h"
 #include "VictoryPC.generated.h"

--- a/Source/VictoryBPLibrary/VictoryBPLibrary.Build.cs
+++ b/Source/VictoryBPLibrary/VictoryBPLibrary.Build.cs
@@ -36,7 +36,8 @@ public class VictoryBPLibrary : ModuleRules
 		PublicDependencyModuleNames.AddRange(
 			new string[]
 			{
-				"Core"
+				"Core",
+                "HTTP"
 				
 				// ... add other public dependencies that you statically link with here ...
 			}
@@ -52,8 +53,6 @@ public class VictoryBPLibrary : ModuleRules
 				
 				"RHI",
 				"RenderCore",
-				 
-				"HTTP",
 				"UMG", "Slate", "SlateCore",
 				
 				"ImageWrapper",


### PR DESCRIPTION
As title says, originally when the UE4 target is set to not to use unity-build (`bUseUnityBuild = false;`), this plugin misses some headers which were silently included in the combined unity compilation unit.