### PR TITLE
Clone__StaticMeshActor: Swap a couple of lines to avoid static mobili…

### DIFF
--- a/Source/VictoryBPLibrary/Private/VictoryBPFunctionLibrary.cpp
+++ b/Source/VictoryBPLibrary/Private/VictoryBPFunctionLibrary.cpp
@@ -2630,11 +2630,11 @@ AStaticMeshActor* UVictoryBPFunctionLibrary::Clone__StaticMeshActor(UObject* Wor
 	
 	if(!NewSMA) return NULL;
 	
+	//Mobility
+	NewSMA->GetStaticMeshComponent()->SetMobility(EComponentMobility::Movable);
+
 	//Copy Transform
 	NewSMA->SetActorTransform(ToClone->GetTransform());
-	
-	//Mobility
-	NewSMA->GetStaticMeshComponent()->SetMobility(EComponentMobility::Movable	);
 	
 	//copy static mesh
 	NewSMA->GetStaticMeshComponent()->SetStaticMesh(ToClone->GetStaticMeshComponent()->GetStaticMesh());


### PR DESCRIPTION
…ty warning.

Suppresses "Warning Mobility of ____ : _____________has to be 'Movable' if you'd like to move" in Close Static Mesh Actor node.